### PR TITLE
Add Hashrates module to the API

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -129,6 +129,12 @@ class Api extends DataCollector {
     const oldStats = this.stats
     const stats = await this.Stats.run('getLatest')
     if (!stats) return
+
+    const { Hashrate } = this
+    const blockNumber = parseInt(stats.data.blockNumber)
+    const hashrates = await Hashrate.getHashrates(blockNumber)
+    stats.data.hashrates = hashrates
+
     this.stats = Object.assign({}, stats)
     if (stats.timestamp !== oldStats.timestamp) {
       this.events.emit('newStats', this.stats)

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -14,6 +14,7 @@ import {
   getDelayedFields,
   getModule
 } from './lib/apiTools'
+import Hashrates from './modules/Hashrate';
 
 const lastLimit = config.api.lastBlocks || 10
 const collections = config.blocks.collections
@@ -35,6 +36,7 @@ class Api extends DataCollector {
     this.addItem(collections.Events, 'Event', Event)
     this.addItem(collections.TokensAddrs, 'Token', TokenAccount)
     this.addItem(collections.Stats, 'Stats', Stats)
+    this.addItem(collections.Blocks, 'Hashrate', Hashrates)
   }
   tick () {
     this.setLastBlocks()

--- a/src/api/lib/DataCollector/DataCollectorItem.js
+++ b/src/api/lib/DataCollector/DataCollectorItem.js
@@ -46,6 +46,15 @@ export class DataCollectorItem {
     return { data }
   }
 
+  async getLatest (query, project) {
+    project = project || this.getDefaultsFields()
+    let data = await this.db.find(query, { project })
+      .sort({ timestamp: -1 })
+      .limit(1)
+      .next()
+    return { data }
+  }
+
   async setFieldsTypes () {
     let types = await getFieldsTypes(this.db)
     this.fieldsTypes = types

--- a/src/api/lib/hashrateCalculator.js
+++ b/src/api/lib/hashrateCalculator.js
@@ -1,0 +1,37 @@
+const BigNumber = require('bignumber.js');
+
+export const PRECISION_DECIMALS = 3;
+
+export class HashrateCalculator {
+    constructor() {
+    }
+
+    hashratePercentagePerMiner(blocks) {
+        if (!Array.isArray(blocks)) {
+            return {}
+        }
+
+        if (!blocks.length) {
+            return {}
+        }
+
+        const diffPerMiner = {}
+        let totalDiff = new BigNumber(0);
+
+        for (const block of blocks) {
+            if (Object.keys(diffPerMiner).indexOf(block.miner) === -1) {
+                diffPerMiner[block.miner] = new BigNumber(0);
+            }
+
+            const bnDiff = new BigNumber(block.difficulty);
+            diffPerMiner[block.miner] = diffPerMiner[block.miner].plus(bnDiff);
+            totalDiff = totalDiff.plus(bnDiff);
+        }
+
+        for (const m of Object.keys(diffPerMiner)) {
+            diffPerMiner[m] = diffPerMiner[m].dividedBy(totalDiff).toPrecision(PRECISION_DECIMALS);
+        }
+
+        return diffPerMiner;
+    }
+}

--- a/src/api/modules/Hashrate.js
+++ b/src/api/modules/Hashrate.js
@@ -1,0 +1,45 @@
+import { DataCollectorItem } from '../lib/DataCollector'
+import { HashrateCalculator } from '../lib/hashrateCalculator'
+
+export const HASHRATE_PERIODS = {
+    '1w': {
+        depth: 20160
+    },
+    '1d': {
+        depth: 2880
+    },
+    '1h': {
+        depth: 120
+    }
+}
+
+export class Hashrates extends DataCollectorItem {
+    constructor (collection, key, parent) {
+        super(collection, key, parent)
+        this.hashrateCalculator = new HashrateCalculator()
+        this.publicActions = {
+            getHashrates: async (params) => {
+                return {
+                    data: await this.getHashrates(params.blockNumber)
+                }
+            }
+        }
+    }
+
+    async getHashrates(blockNumber) {
+        let hashrates = {}
+
+        for (const period of Object.keys(HASHRATE_PERIODS)) {
+            const depth = HASHRATE_PERIODS[period].depth
+            const blocks = await this.db.find({ number: { $gte: blockNumber - depth, $lte: blockNumber } })
+                .project({ _id: 0, miner: 1, difficulty: 1 })
+                .toArray()
+
+            hashrates[period] = this.hashrateCalculator.hashratePercentagePerMiner(blocks)
+        }
+
+        return hashrates
+    }
+}
+
+export default Hashrates

--- a/src/api/modules/Hashrate.js
+++ b/src/api/modules/Hashrate.js
@@ -35,7 +35,7 @@ export class Hashrates extends DataCollectorItem {
                 .project({ _id: 0, miner: 1, difficulty: 1 })
                 .toArray()
 
-            hashrates[period] = this.hashrateCalculator.hashratePercentagePerMiner(blocks)
+            hashrates[period] = this.hashrateCalculator.hashrates(blocks)
         }
 
         return hashrates

--- a/src/api/modules/Stats.js
+++ b/src/api/modules/Stats.js
@@ -59,7 +59,7 @@ export class Stats extends DataCollectorItem {
        *          $ref: '#/responses/NotFound'
        */
       getLatest: () => {
-        return this.getOne()
+        return this.getLatest()
       }
     }
   }

--- a/test/services/hashrateCalculator.js
+++ b/test/services/hashrateCalculator.js
@@ -3,6 +3,8 @@ const BigNumber = require('bignumber.js');
 const HashrateCalculator = require('../../src/api/lib/hashrateCalculator.js').HashrateCalculator;
 
 describe('hashrateCalculator', () => {
+    const exa = (n) => new BigNumber(`${n}e50`);
+
     context('hashratePercentagePerMiner', () => {
         it('returns an empty object when argument is not an array', () => {
             const calc = new HashrateCalculator();
@@ -130,7 +132,6 @@ describe('hashrateCalculator', () => {
     });
 
     context('hashratePerMiner', () => {
-        const exa = (n) => new BigNumber(`${n}e50`);
         const START = 1;
 
         it('returns an empty object when argument is not an array', () => {
@@ -205,4 +206,34 @@ describe('hashrateCalculator', () => {
             });
         });
     });
+
+    context('hashrates', () => {
+        const START = 1;
+
+        it('returns the cumulative diff divided the time elapsed between first and last block for multiple miners', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: exa(1), timestamp: START },
+                { miner: '0x0b', difficulty: exa(2), timestamp: START+1 },
+                { miner: '0x0a', difficulty: exa(3), timestamp: START+2 },
+                { miner: '0x0c', difficulty: exa(4), timestamp: START+3 },
+                { miner: '0x0d', difficulty: exa(5), timestamp: START+4 },
+                { miner: '0x0a', difficulty: exa(6), timestamp: START+5 },
+                { miner: '0x0a', difficulty: exa(7), timestamp: START+6 },
+                { miner: '0x0b', difficulty: exa(8), timestamp: START+7 },
+                { miner: '0x0a', difficulty: exa(9), timestamp: START+8 },
+                { miner: '0x0c', difficulty: exa(10), timestamp: START+9 },
+                { miner: '0x0c', difficulty: exa(11), timestamp: START+10 },
+            ]
+            const hashrate = calc.hashrates(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': { avg: '2.600 EHs', perc: 0.394 }, // 26
+                '0x0b': { avg: '1.000 EHs', perc: 0.152 }, // 10
+                '0x0c': { avg: '2.500 EHs', perc: 0.379 }, // 25
+                '0x0d': { avg: '0.500 EHs', perc: 0.076 } // 5
+            });
+        });
+    })
 });

--- a/test/services/hashrateCalculator.js
+++ b/test/services/hashrateCalculator.js
@@ -1,0 +1,130 @@
+const assert = require('assert');
+const HashrateCalculator = require('../../src/api/lib/hashrateCalculator.js').HashrateCalculator;
+
+describe('hashrateCalculator', () => {
+    context('hashratePerMiner', () => {
+        it('returns an empty object when argument is not an array', () => {
+            const calc = new HashrateCalculator();
+
+            const hashrate = calc.hashratePercentagePerMiner();
+
+            assert.deepEqual(hashrate, {});
+        });
+
+        it('returns an empty object when no blocks', () => {
+            const calc = new HashrateCalculator();
+
+            const hashrate = calc.hashratePercentagePerMiner([]);
+
+            assert.deepEqual(hashrate, {});
+        });
+
+        it('returns 1 for only one miner and 1 block', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e6' }
+            ]
+            const hashrate = calc.hashratePercentagePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': 1
+            });
+        });
+
+        it('returns 0.5 for two miners that mined one block with the same block difficulty each', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0b', difficulty: '0x11f36beaf6690ac7e6' },
+            ]
+            const hashrate = calc.hashratePercentagePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': 0.5,
+                '0x0b': 0.5
+            });
+        });
+
+        it('returns 1 for one miner that mined more than one block', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e3' },
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e2' },
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e1' },
+            ]
+            const hashrate = calc.hashratePercentagePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': 1
+            });
+        });
+
+        it('returns 0.25 for four miners that mined one block with the same block difficulty each', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0b', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0c', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0d', difficulty: '0x11f36beaf6690ac7e6' }
+            ]
+            const hashrate = calc.hashratePercentagePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': 0.25,
+                '0x0b': 0.25,
+                '0x0c': 0.25,
+                '0x0d': 0.25
+            });
+        });
+
+        it('returns the corresponding value when four miners mine one block each with different difficulty', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0b', difficulty: '0x13b768fb4f683f5fd5' },
+                { miner: '0x0c', difficulty: '0x0f54a7810c212d7df0' },
+                { miner: '0x0d', difficulty: '0x0f54a7810c212d7df0' }
+            ]
+            const hashrate = calc.hashratePercentagePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': 0.263,
+                '0x0b': 0.289,
+                '0x0c': 0.224,
+                '0x0d': 0.224
+            });
+        });
+
+        it('returns the corresponding value when four miners mine several blocks each with different difficulty', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0b', difficulty: '0x13b768fb4f683f5fd5' },
+                { miner: '0x0a', difficulty: '0x13b768fb4f683f5fd5' },
+                { miner: '0x0c', difficulty: '0x10050a0cc225820cdd' },
+                { miner: '0x0d', difficulty: '0x10050a0cc225820cdd' },
+                { miner: '0x0d', difficulty: '0x0f54a7810c212d7df0' },
+                { miner: '0x0a', difficulty: '0x11f36beaf6690ac7e6' },
+                { miner: '0x0d', difficulty: '0x0f54a7810c212d7d00' },
+                { miner: '0x0c', difficulty: '0x10050a0cc225820cdd' },
+                { miner: '0x0b', difficulty: '0x10050a0cc225820fff' },
+                { miner: '0x0d', difficulty: '0x11f36beaf6690ac7e6' },
+            ]
+            const hashrate = calc.hashratePercentagePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': 0.296,
+                '0x0b': 0.190,
+                '0x0c': 0.170,
+                '0x0d': 0.344
+            });
+        });
+    });
+});

--- a/test/services/hashrateCalculator.js
+++ b/test/services/hashrateCalculator.js
@@ -1,8 +1,9 @@
 const assert = require('assert');
+const BigNumber = require('bignumber.js');
 const HashrateCalculator = require('../../src/api/lib/hashrateCalculator.js').HashrateCalculator;
 
 describe('hashrateCalculator', () => {
-    context('hashratePerMiner', () => {
+    context('hashratePercentagePerMiner', () => {
         it('returns an empty object when argument is not an array', () => {
             const calc = new HashrateCalculator();
 
@@ -124,6 +125,83 @@ describe('hashrateCalculator', () => {
                 '0x0b': 0.190,
                 '0x0c': 0.170,
                 '0x0d': 0.344
+            });
+        });
+    });
+
+    context('hashratePerMiner', () => {
+        const exa = (n) => new BigNumber(`${n}e50`);
+        const START = 1;
+
+        it('returns an empty object when argument is not an array', () => {
+            const calc = new HashrateCalculator();
+
+            const hashrate = calc.hashratePerMiner();
+
+            assert.deepEqual(hashrate, {});
+        });
+
+        it('returns an empty object when no blocks', () => {
+            const calc = new HashrateCalculator();
+
+            const hashrate = calc.hashratePerMiner([]);
+
+            assert.deepEqual(hashrate, {});
+        });
+
+        it('returns the same diff as hashrate for one block', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: exa(1), timestamp: START }
+            ]
+            const hashrate = calc.hashratePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': '1.000 EHs'
+            });
+        });
+
+        it('returns the cumulative diff divided the time elapsed between first and last block for one miner', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: exa(1), timestamp: START },
+                { miner: '0x0a', difficulty: exa(1), timestamp: START+1 },
+                { miner: '0x0a', difficulty: exa(1), timestamp: START+2 },
+                { miner: '0x0a', difficulty: exa(1), timestamp: START+3 },
+                { miner: '0x0a', difficulty: exa(1), timestamp: START+4 }
+            ]
+            const hashrate = calc.hashratePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': '1.250 EHs'
+            });
+        });
+
+        it('returns the cumulative diff divided the time elapsed between first and last block for multiple miners', () => {
+            const calc = new HashrateCalculator();
+
+            const blocks = [
+                { miner: '0x0a', difficulty: exa(1), timestamp: START },
+                { miner: '0x0b', difficulty: exa(2), timestamp: START+1 },
+                { miner: '0x0a', difficulty: exa(3), timestamp: START+2 },
+                { miner: '0x0c', difficulty: exa(4), timestamp: START+3 },
+                { miner: '0x0d', difficulty: exa(5), timestamp: START+4 },
+                { miner: '0x0a', difficulty: exa(6), timestamp: START+5 },
+                { miner: '0x0a', difficulty: exa(7), timestamp: START+6 },
+                { miner: '0x0b', difficulty: exa(8), timestamp: START+7 },
+                { miner: '0x0a', difficulty: exa(9), timestamp: START+8 },
+                { miner: '0x0c', difficulty: exa(10), timestamp: START+9 },
+                { miner: '0x0c', difficulty: exa(11), timestamp: START+10 },
+            ]
+            const hashrate = calc.hashratePerMiner(blocks);
+
+            assert.deepEqual(hashrate, {
+                '0x0a': '2.600 EHs', // 26
+                '0x0b': '1.000 EHs', // 10
+                '0x0c': '2.500 EHs', // 25
+                '0x0d': '0.500 EHs' // 5
             });
         });
     });


### PR DESCRIPTION
Add a `Hashrate` module which exposes the method `getHashrates(blockNumber)` which calculates the average and percentage of hashrate for each miner for an approximate range of one hour, day and week.

Add the hashrate calculation to the stats object built in `Api::updateStats` as well.

Further improvements are planed for the future, such as using timestamp ranges instead of blocks.