### PR TITLE
adding tool to uppdate proxy service on previous blocks

### DIFF
--- a/dist/services/classes/Contract.js
+++ b/dist/services/classes/Contract.js
@@ -1,5 +1,5 @@
 "use strict";Object.defineProperty(exports, "__esModule", { value: true });exports.default = void 0;var _BcThing = require("./BcThing");
-var _rskContractParser = _interopRequireDefault(require("@rsksmart/rsk-contract-parser"));
+var _rskContractParser = require("@rsksmart/rsk-contract-parser");
 var _types = require("../../lib/types");
 var _TokenAddress = _interopRequireDefault(require("./TokenAddress"));
 var _utils = require("../../lib/utils");function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}
@@ -35,7 +35,12 @@ class Contract extends _BcThing.BcThing {
           if (!deployedCode) throw new Error(`Missing deployed code for contract: ${this.address}`);
           let info = await this.parser.getContractInfo(deployedCode, contract);
           let { interfaces, methods } = info;
-          if (interfaces.length) this.setData({ contractInterfaces: interfaces });
+          if (interfaces.length) {
+            this.setData({ contractInterfaces: interfaces });
+            if (interfaces.includes(_rskContractParser.types.contractsInterfaces.EIP1167)) {
+              this.setData({ masterCopy: this.parser.getEip1167MasterCopy(deployedCode) });
+            }
+          }
           if (methods) this.setData({ contractMethods: methods });
         }
         let { contractInterfaces, tokenData } = this.data;
@@ -62,7 +67,7 @@ class Contract extends _BcThing.BcThing {
       let { nod3, initConfig, log } = this;
       if (!this.parser) {
         let abi = await this.getAbi();
-        this.parser = new _rskContractParser.default({ abi, nod3, initConfig, log });
+        this.parser = new _rskContractParser.ContractParser({ abi, nod3, initConfig, log });
       }
       return this.parser;
     } catch (err) {

--- a/dist/tools/updateAddressWithEIP1167.js
+++ b/dist/tools/updateAddressWithEIP1167.js
@@ -1,10 +1,13 @@
 "use strict";Object.defineProperty(exports, "__esModule", { value: true });exports.start = start;var _dataSource = _interopRequireDefault(require("../lib/dataSource.js"));
-var _rskContractParser = require("@rsksmart/rsk-contract-parser");function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}
+var _rskContractParser = require("../../.yalc/@rsksmart/rsk-contract-parser");function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}
 
 async function start() {
   const parser = new _rskContractParser.ContractParser();
   const { collections } = await (0, _dataSource.default)();
-  const collectionWithProxies = await collections.Addrs.find({ code: { $regex: /^(0x)?363d3d373d3d3d363d73[a-f0-9]{40}5af43d82803e903d91602b57fd5bf3$/, $options: 'i' } }).toArray();
+  const { EIP_1167_PREFIX, EIP_1167_SUFFIX } = _rskContractParser.Constants;
+  const proxyRegex = new RegExp(`^(0x)?${EIP_1167_PREFIX}[a-f0-9]{40}${EIP_1167_SUFFIX}$`, 'i');
+  const collectionWithProxies = await collections.Addrs.find({ code: proxyRegex }).toArray();
+
   for (let i = 0; i < collectionWithProxies.length; i++) {
     if (!collectionWithProxies[i].masterCopy && collectionWithProxies[i].code) {
       const updateResult = await collections.Addrs.updateOne({ _id: collectionWithProxies[i]._id },

--- a/dist/tools/updateAddressWithEIP1167.js
+++ b/dist/tools/updateAddressWithEIP1167.js
@@ -1,0 +1,19 @@
+"use strict";Object.defineProperty(exports, "__esModule", { value: true });exports.start = start;var _dataSource = _interopRequireDefault(require("../lib/dataSource.js"));
+var _rskContractParser = require("@rsksmart/rsk-contract-parser");function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}
+
+async function start() {
+  const parser = new _rskContractParser.ContractParser();
+  const { collections } = await (0, _dataSource.default)();
+  const collectionWithProxies = await collections.Addrs.find({ code: { $regex: /^(0x)?363d3d373d3d3d363d73[a-f0-9]{40}5af43d82803e903d91602b57fd5bf3$/, $options: 'i' } }).toArray();
+  for (let i = 0; i < collectionWithProxies.length; i++) {
+    if (!collectionWithProxies[i].masterCopy && collectionWithProxies[i].code) {
+      const updateResult = await collections.Addrs.updateOne({ _id: collectionWithProxies[i]._id },
+      { $set: { masterCopy: parser.getEip1167MasterCopy(collectionWithProxies[i].code) } });
+      console.log('updating id => ', collectionWithProxies[i]._id);
+      console.log(updateResult);
+    }
+  }
+  process.exit(0);
+}
+
+start();

--- a/src/services/classes/Contract.js
+++ b/src/services/classes/Contract.js
@@ -36,9 +36,9 @@ class Contract extends BcThing {
           let info = await this.parser.getContractInfo(deployedCode, contract)
           let { interfaces, methods } = info
           if (interfaces.length) {
-            this.setData({ contractInterfaces: interfaces });
-            if(interfaces.includes(types.contractsInterfaces.EIP1167)){
-              this.setData({ masterCopy : this.parser.getEip1167MasterCopy(deployedCode)});
+            this.setData({ contractInterfaces: interfaces })
+            if (interfaces.includes(types.contractsInterfaces.EIP1167)) {
+              this.setData({ masterCopy: this.parser.getEip1167MasterCopy(deployedCode) })
             }
           }
           if (methods) this.setData({ contractMethods: methods })

--- a/src/tools/updateAddressWithEIP1167.js
+++ b/src/tools/updateAddressWithEIP1167.js
@@ -1,24 +1,19 @@
 import dataSource from '../lib/dataSource.js'
+import { ContractParser } from '@rsksmart/rsk-contract-parser'
 
-const EIP_1167_PREFIX = '363d3d373d3d3d363d73'
-const EIP_1167_SUFFIX = '5af43d82803e903d91602b57fd5bf3'
 export async function start () {
+  const parser = new ContractParser()
   const { collections } = await dataSource()
   const collectionWithProxies = await collections.Addrs.find({code: { $regex: /^(0x)?363d3d373d3d3d363d73[a-f0-9]{40}5af43d82803e903d91602b57fd5bf3$/, $options: 'i' }}).toArray()
   for (let i = 0; i < collectionWithProxies.length; i++) {
     if (!collectionWithProxies[i].masterCopy && collectionWithProxies[i].code) {
       const updateResult = await collections.Addrs.updateOne({_id: collectionWithProxies[i]._id},
-        {$set: {masterCopy: getEip1167MasterCopy(collectionWithProxies[i].code)}})
+        {$set: {masterCopy: parser.getEip1167MasterCopy(collectionWithProxies[i].code)}})
       console.log('updating id => ', collectionWithProxies[i]._id)
       console.log(updateResult)
     }
   }
   process.exit(0)
-}
-
-function getEip1167MasterCopy (bytecode) {
-  const implementationAddress = bytecode.replace(EIP_1167_PREFIX, '').replace(EIP_1167_SUFFIX, '')
-  return implementationAddress
 }
 
 start()

--- a/src/tools/updateAddressWithEIP1167.js
+++ b/src/tools/updateAddressWithEIP1167.js
@@ -1,0 +1,24 @@
+import dataSource from '../lib/dataSource.js'
+
+const EIP_1167_PREFIX = '363d3d373d3d3d363d73'
+const EIP_1167_SUFFIX = '5af43d82803e903d91602b57fd5bf3'
+export async function start () {
+  const { collections } = await dataSource()
+  const collectionWithProxies = await collections.Addrs.find({code: { $regex: /^(0x)?363d3d373d3d3d363d73[a-f0-9]{40}5af43d82803e903d91602b57fd5bf3$/, $options: 'i' }}).toArray()
+  for (let i = 0; i < collectionWithProxies.length; i++) {
+    if (!collectionWithProxies[i].masterCopy && collectionWithProxies[i].code) {
+      const updateResult = await collections.Addrs.updateOne({_id: collectionWithProxies[i]._id},
+        {$set: {masterCopy: getEip1167MasterCopy(collectionWithProxies[i].code)}})
+      console.log('updating id => ', collectionWithProxies[i]._id)
+      console.log(updateResult)
+    }
+  }
+  process.exit(0)
+}
+
+function getEip1167MasterCopy (bytecode) {
+  const implementationAddress = bytecode.replace(EIP_1167_PREFIX, '').replace(EIP_1167_SUFFIX, '')
+  return implementationAddress
+}
+
+start()

--- a/src/tools/updateAddressWithEIP1167.js
+++ b/src/tools/updateAddressWithEIP1167.js
@@ -1,10 +1,13 @@
 import dataSource from '../lib/dataSource.js'
-import { ContractParser } from '@rsksmart/rsk-contract-parser'
+import { ContractParser, Constants } from '../../.yalc/@rsksmart/rsk-contract-parser'
 
 export async function start () {
   const parser = new ContractParser()
   const { collections } = await dataSource()
-  const collectionWithProxies = await collections.Addrs.find({code: { $regex: /^(0x)?363d3d373d3d3d363d73[a-f0-9]{40}5af43d82803e903d91602b57fd5bf3$/, $options: 'i' }}).toArray()
+  const { EIP_1167_PREFIX, EIP_1167_SUFFIX } = Constants
+  const proxyRegex = new RegExp(`^(0x)?${EIP_1167_PREFIX}[a-f0-9]{40}${EIP_1167_SUFFIX}$`, 'i')
+  const collectionWithProxies = await collections.Addrs.find({ code: proxyRegex }).toArray()
+
   for (let i = 0; i < collectionWithProxies.length; i++) {
     if (!collectionWithProxies[i].masterCopy && collectionWithProxies[i].code) {
       const updateResult = await collections.Addrs.updateOne({_id: collectionWithProxies[i]._id},


### PR DESCRIPTION
adding tool to update exiting addresses with proxies EIP1167 and add masterCopy Field on mongodb.

this script should be run with `node dist/tools/updateAddressWithEIP1167.js`, this script it's to update the already exiting address that accomplish with EIP1167 proxy standard and add `masterCopy` field for the one's that accomplish with the requirements, so we can display that fields on the front end `rsk-explorer` 