### PR TITLE
fix: workaround when building the block

### DIFF
--- a/src/services/classes/Address.js
+++ b/src/services/classes/Address.js
@@ -13,7 +13,7 @@ export class Address extends BcThing {
     if (!this.isAddress(address)) throw new Error((`Invalid address: ${address}`))
     this.isZeroAddress = isZeroAddress(address)
     this.bcSearch = BcSearch(nod3)
-    this.address = address
+    this.address = address ? address.toLowerCase() : address;
     this.fetched = false
     this.collection = (collections) ? collections.Addrs : undefined
     this.contract = undefined


### PR DESCRIPTION
It looks like in some point the address change character cases.

Step to reproduce it (testnet):

`$> node --experimental-json-modules --experimental-specifier-resolution=node src/tools/getBlock.js 290002`

Before:

```
Getting block 2900022
Block fetch error Error: Missing deployment data for 0x628feD0B05AA43B715Db34198F7Db9036C06AeA5
    at Address.searchDeploymentData (file:///Users/patricio/workspace/research/explorer/rsk-explorer-api/src/services/classes/Address.js:148:24)

```

After:

```
Getting block 2900022
 Get time: 53477ms
```

_**Note**: this is not a final fix, but a hotfix. A proper analysis should be made, and a proper error handling refactor should be made._