### PR TITLE
Make bn to hex use ethers toHexString

### DIFF
--- a/dist/lib/utils.js
+++ b/dist/lib/utils.js
@@ -6,7 +6,9 @@ var _rskUtils = require("@rsksmart/rsk-utils");
 Object.keys(_rskUtils).forEach(function (key) {if (key === "default" || key === "__esModule") return;if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;if (key in exports && exports[key] === _rskUtils[key]) return;Object.defineProperty(exports, key, { enumerable: true, get: function () {return _rskUtils[key];} });});var _crypto = _interopRequireDefault(require("crypto"));function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}
 
 const bigNumberDoc = bigNumber => {
-  return '0x' + bigNumber.toString(16);
+  return typeof bigNumber.toHexString !== 'undefined' ?
+  bigNumber.toHexString() :
+  '0x' + bigNumber.toString(16);
 };exports.bigNumberDoc = bigNumberDoc;
 
 const isBigNumber = value => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsk-explorer-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -6,7 +6,9 @@ import crypto from 'crypto'
 export * from '@rsksmart/rsk-utils'
 
 export const bigNumberDoc = bigNumber => {
-  return '0x' + bigNumber.toString(16)
+  return typeof bigNumber.toHexString !== 'undefined'
+    ? bigNumber.toHexString()
+    : '0x' + bigNumber.toString(16)
 }
 
 export const isBigNumber = value => {


### PR DESCRIPTION
`ethers` big numbers use `toHexString` instead of `toString(16)`. This change is added because the new impl of the contract parser uses `ethers` abi decoder

https://github.com/rsksmart/rsk-contract-parser/pull/20