### PR TITLE
fix: support EIP1967 proxy tokens balances fetch

### DIFF
--- a/src/services/classes/TokenAddress.js
+++ b/src/services/classes/TokenAddress.js
@@ -24,19 +24,19 @@ export class TokenAddress extends BcThing {
     }
   }
 
-  async fetchTokenAddressBalance () {
-    const { isZeroAddress, Contract, address } = this
-    if (isZeroAddress) return null
+  // async fetchTokenAddressBalance () {
+  //   const { isZeroAddress, Contract, address } = this
+  //   if (isZeroAddress) return null
 
-    try {
-      const balance = await Contract.call('balanceOf', [address])
-      this.setTokenAddressBalance(balance)
-      return this.getData(true)
-    } catch (err) {
-      this.log.error(`Error fetching token balance for tokenAddress ${address}`, err)
-      return Promise.reject(err)
-    }
-  }
+  //   try {
+  //     const balance = await Contract.call('balanceOf', [address])
+  //     this.setTokenAddressBalance(balance)
+  //     return this.getData(true)
+  //   } catch (err) {
+  //     this.log.error(`Error fetching token balance for tokenAddress ${address}`, err)
+  //     return Promise.reject(err)
+  //   }
+  // }
 
   setTokenAddressBalance (balance) {
     this.setData({ balance })


### PR DESCRIPTION
- support token balances fetch for EIP1967 proxy token contracts
- fetch token balances for the particular processed block instead of always fetching latest balance
- better error handling when fetching token balances

## Token account View:
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/6b1cde1b-7433-4f05-b047-7214995ff21a">

## Address tokens View:

### Rootstock Explorer:
<img width="1042" alt="Screenshot 2024-10-01 at 3 38 51 PM" src="https://github.com/user-attachments/assets/48b2e6e1-401c-49be-83b2-15084f339b04">

### Blockscout Explorer:
<img width="1473" alt="Screenshot 2024-10-01 at 3 39 29 PM" src="https://github.com/user-attachments/assets/bc03c65c-409d-403e-b4aa-e4824ba0e880">
