### PR TITLE
Refactor/dv 1237 update contract events updater tool

### DIFF
--- a/src/services/classes/ContractEventsUpdater.js
+++ b/src/services/classes/ContractEventsUpdater.js
@@ -208,6 +208,11 @@ export default class ContractEventsUpdater {
           eventDebugData: null
         }
 
+        const debugData = {
+          event,
+          parsedEvent: null
+        }
+
         result.push(eventDetails)
 
         try {
@@ -227,6 +232,7 @@ export default class ContractEventsUpdater {
 
           // Parse event
           const [parsedEvent] = parser.parseTxLogs([event])
+          debugData.parsedEvent = parsedEvent
 
           // Undecodeable events
           if (parsedEvent.event === null) throw new Error('Unable to decode event')
@@ -243,7 +249,7 @@ export default class ContractEventsUpdater {
           this.log.error(`Error processing event ${event.eventId} for contract ${event.address} at block ${event.blockNumber}, tx ${event.transactionHash}, logIndex: ${event.logIndex}: ${error.message}. Skipping...`)
           eventDetails.error = true
           eventDetails.errorMessage = error.message
-          eventDetails.eventDebugData = event
+          eventDetails.eventDebugData = debugData
         }
       }
 

--- a/src/tools/updateContractEvents.js
+++ b/src/tools/updateContractEvents.js
@@ -1,5 +1,7 @@
 import { isAddress } from '@rsksmart/rsk-utils/dist/addresses'
 import ContractEventsUpdater from '../services/classes/ContractEventsUpdater'
+import fs from 'fs'
+import path from 'path'
 
 // Sometimes, contract events are not decoded correctly. This could happen due to several reasons
 // The most probable ones are:
@@ -62,7 +64,14 @@ async function main () {
 
     const contractEventsUpdater = new ContractEventsUpdater()
     const result = await contractEventsUpdater.updateContractEvents(targetAddress, parsedPageSize, parsedSinceBlockNumber)
-    console.dir(result, { depth: null })
+
+    console.log(`Saving result file...`)
+    const fileName = `events-update-${targetAddress}-${Date.now()}.json`
+    const resultFilePath = path.join(__dirname, fileName)
+    fs.writeFileSync(resultFilePath, JSON.stringify(result, null, 2))
+    console.log(`Result file saved to ${resultFilePath}`)
+
+    process.exit(0)
   } catch (error) {
     console.log(`[Tool ${toolName}]: Error updating contract events`)
     console.error(error)


### PR DESCRIPTION
This PR modifies the Contract events updater tool to handle border cases, like proxy events.

Other minor adjustments:
- add more debug data in case of errors
- Improve processing and logging.
- Save result to a file

## Execution examples 

### USDCe events
![image](https://github.com/user-attachments/assets/842df393-c362-4fe2-84cf-b6ffd2a55e57)
...
![image](https://github.com/user-attachments/assets/1b3225dc-fcfb-49f3-ad41-0925c2f5a40a)

### Bridge events
![image](https://github.com/user-attachments/assets/7e6980ff-7cef-4a7f-afc9-c1460b57b986)
...
![image](https://github.com/user-attachments/assets/16ca0235-1730-493f-bd22-70a0e7c88570)

## Result file example

```
{
  "contractDetails": {
    "address": "0x74c9f2b00581f1b11aa7ff05aa9f608b7389de67",
    "isProxy": true,
    "implementationAddress": "0x40461291347e1ecbb09499f3371d3f17f10d7159",
    "beaconAddress": null,
    "proxyType": "Open Zeppelin Unstructured Storage (pre ERC1967)",
    "methods": [
      "CANCEL_AUTHORIZATION_TYPEHASH()",
      "DOMAIN_SEPARATOR()",
      "PERMIT_TYPEHASH()",
      "RECEIVE_WITH_AUTHORIZATION_TYPEHASH()",
      "TRANSFER_WITH_AUTHORIZATION_TYPEHASH()",
      "allowance(address,address)",
      "approve(address,uint256)",
      "authorizationState(address,bytes32)",
      "balanceOf(address)",
      "blacklist(address)",
      "blacklister()",
      "burn(uint256)",
      "cancelAuthorization(address,bytes32,uint8,bytes32,bytes32)",
      "cancelAuthorization(address,bytes32,bytes)",
      "configureMinter(address,uint256)",
      "currency()",
      "decimals()",
      "decreaseAllowance(address,uint256)",
      "increaseAllowance(address,uint256)",
      "initialize(string,string,string,uint8,address,address,address,address)",
      "initializeV2(string)",
      "initializeV2_1(address)",
      "initializeV2_2(address[],string)",
      "isBlacklisted(address)",
      "isMinter(address)",
      "masterMinter()",
      "mint(address,uint256)",
      "minterAllowance(address)",
      "name()",
      "nonces(address)",
      "owner()",
      "pause()",
      "paused()",
      "pauser()",
      "permit(address,address,uint256,uint256,bytes)",
      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)",
      "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)",
      "receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)",
      "removeMinter(address)",
      "rescueERC20(address,address,uint256)",
      "rescuer()",
      "symbol()",
      "totalSupply()",
      "transfer(address,uint256)",
      "transferFrom(address,address,uint256)",
      "transferOwnership(address)",
      "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,bytes)",
      "transferWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)",
      "unBlacklist(address)",
      "unpause()",
      "updateBlacklister(address)",
      "updateMasterMinter(address)",
      "updatePauser(address)",
      "updateRescuer(address)",
      "version()"
    ],
    "interfaces": [
      "ERC20",
      "ERC1822"
    ]
  },
  "verifiedAbi": true,
  "updatedEvents": {
    "amount": 1456,
    "events": [
      {
        "eventId": "0754da300100023972b2ebddf3c51426",
        "name": "Approval",
        "blockNumber": 7687587,
        "transactionHash": "0x2df6754eed3cdcc44ce3a4469ade30afdefad082bf8f2587345093ee70c51ff0",
        "logIndex": 0,
        "timestamp": 1750361373,
        "decoded": true,
        "updated": true,
        "error": false,
        "errorMessage": null,
        "eventDebugData": null
      },
      {
        "eventId": "0752e9f001002e73949a5a5ab4171c80",
        "name": "Transfer",
        "blockNumber": 7679647,
        "transactionHash": "0x993ca02fc7c70096351b36e626e8e245de2f814d7a61bf7fe6883ea85694b2d6",
        "logIndex": 2,
        "timestamp": 1750170084,
        "decoded": true,
        "updated": true,
        "error": false,
        "errorMessage": null,
        "eventDebugData": null
      },
      {
        "eventId": "0752e9f001001e73949a5a5ab4171c80",
        "name": "Burn",
        "blockNumber": 7679647,
        "transactionHash": "0x993ca02fc7c70096351b36e626e8e245de2f814d7a61bf7fe6883ea85694b2d6",
        "logIndex": 1,
        "timestamp": 1750170084,
        "decoded": true,
        "updated": true,
        "error": false,
        "errorMessage": null,
        "eventDebugData": null
      },
... more items
```

