### PR TITLE
refactor: update contracts parser version. Update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@prisma/client": "^5.11.0",
     "@rsksmart/nod3": "^0.5.0",
-    "@rsksmart/rsk-contract-parser": "^2.0.9",
+    "@rsksmart/rsk-contract-parser": "^2.1.0",
     "@rsksmart/rsk-js-cli": "^1.0.0",
     "@rsksmart/rsk-precompiled-abis": "^7.1.0-LOVELL",
     "@rsksmart/rsk-utils": "^1.1.0",

--- a/test/indexer/entities/Contract/testContracts/USDCe.js
+++ b/test/indexer/entities/Contract/testContracts/USDCe.js
@@ -204,7 +204,7 @@ export const USDCe = {
       'removeMinter(address)',
       'burn(uint256)'
     ],
-    contractInterfaces: ['ERC20', 'ERC1822'],
+    contractInterfaces: ['ERC20'],
     name: 'Bridged USDC (Stargate)',
     symbol: 'USDC.e',
     decimals: 6,
@@ -360,7 +360,7 @@ export const USDCe = {
       'updateRescuer(address)',
       'version()'
     ],
-    contractInterfaces: [ 'ERC20', 'ERC1822' ],
+    contractInterfaces: [ 'ERC20' ],
     name: 'Bridged USDC (Stargate)',
     symbol: 'USDC.e',
     decimals: 6,

--- a/test/indexer/entities/Contract/testContracts/USDRIF.js
+++ b/test/indexer/entities/Contract/testContracts/USDRIF.js
@@ -403,7 +403,6 @@ export const USDRIF = {
     contractInterfaces: [
       'ERC20',
       'ERC165',
-      'ERC1822',
       'ERC1967'
     ],
     contractMethods: [
@@ -667,7 +666,6 @@ export const USDRIF = {
     contractInterfaces: [
       'ERC20',
       'ERC165',
-      'ERC1822',
       'ERC1967'
     ],
     contractMethods: [


### PR DESCRIPTION
This pull request updates dependencies and refines contract interface definitions in test contract files. The main focus is on removing the `ERC1822` interface from several test contracts and upgrading the `@rsksmart/rsk-contract-parser` dependency for improved compatibility.

**Dependency update:**

* Upgraded `@rsksmart/rsk-contract-parser` from version `2.0.9` to `2.1.0` in `package.json`, ensuring the project uses the latest features and bug fixes.

**Test contract interface adjustments:**

* Removed the `ERC1822` interface from the `contractInterfaces` array for the `USDCe` test contract in two places, leaving only `ERC20` as the interface. [[1]](diffhunk://#diff-431b3beddde1adb1f4c579d342f5b2b8fd1ac857f711b6e6b05752da6746a137L207-R207) [[2]](diffhunk://#diff-431b3beddde1adb1f4c579d342f5b2b8fd1ac857f711b6e6b05752da6746a137L363-R363)
* Removed the `ERC1822` interface from the `contractInterfaces` array for the `USDRIF` test contract in two places, keeping `ERC20`, `ERC165`, and `ERC1967`. [[1]](diffhunk://#diff-0281f39323655dfddbe1c206bc6338c166c6111cc803cb2f211d389896b36f0fL406) [[2]](diffhunk://#diff-0281f39323655dfddbe1c206bc6338c166c6111cc803cb2f211d389896b36f0fL670)