### PR TITLE
chore: bump version to 2.2.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsk-explorer-api",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "RSK Explorer API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version number of the `rsk-explorer-api` package. No other changes are included.