### PR TITLE
chore: update rsk-contract-parser to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@prisma/client": "^5.11.0",
     "@rsksmart/nod3": "^0.5.0",
-    "@rsksmart/rsk-contract-parser": "^2.1.0",
+    "@rsksmart/rsk-contract-parser": "^2.2.0",
     "@rsksmart/rsk-js-cli": "^1.0.0",
     "@rsksmart/rsk-precompiled-abis": "^7.1.0-LOVELL",
     "@rsksmart/rsk-utils": "^1.1.0",


### PR DESCRIPTION
This pull request updates a dependency version in the `package.json` file to ensure compatibility with the latest features and bug fixes.

* Dependency update:
  * Upgraded `@rsksmart/rsk-contract-parser` from version `^2.1.0` to `^2.2.0` in `package.json` to use the latest release.