### PR TITLE
chore: remove unused rsk-precompiled-abis dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@rsksmart/nod3": "^0.5.0",
     "@rsksmart/rsk-contract-parser": "^2.1.0",
     "@rsksmart/rsk-js-cli": "^1.0.0",
-    "@rsksmart/rsk-precompiled-abis": "^7.1.0-LOVELL",
     "@rsksmart/rsk-utils": "^1.1.0",
     "bignumber.js": "^7.2.1",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
This pull request makes a small change to the project's dependencies by removing an unused package from the `package.json` file. No other changes are included.

* Removed the `@rsksmart/rsk-precompiled-abis` dependency from `package.json`.