### PR TITLE
chore: bump version to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsk-explorer-api",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "RSK Explorer API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the package version in `package.json` to reflect a new release.

* Increased the version number from `2.3.1` to `2.3.2` in `package.json` to prepare for a new deployment.