### PR TITLE
Add indexes for NFTs efficient queries

### DIFF
--- a/prisma/rsk-explorer-database.sql
+++ b/prisma/rsk-explorer-database.sql
@@ -486,13 +486,13 @@ CREATE INDEX idx_event_transaction_hash_log_index ON event(transaction_hash, log
 CREATE INDEX idx_event_address_event_event_id ON event(address, event, event_id DESC);
 CREATE INDEX idx_event_event ON event(event);
 CREATE INDEX idx_event_lowercase_event ON event(lower((event)::text));
-CREATE INDEX idx_event_addr_t0_t3 ON event(address, topic0, topic3, block_number DESC, log_index DESC);
-CREATE INDEX idx_event_addr_t0_block_log_desc ON event(address, topic0, block_number DESC, log_index DESC);
+CREATE INDEX idx_event_addr_t0_t3 ON event(address, topic0, topic3, block_number DESC, transaction_index DESC, log_index DESC);
+CREATE INDEX idx_event_addr_t0_block_log_desc ON event(address, topic0, block_number DESC, transaction_index DESC, log_index DESC);
 CREATE INDEX idx_event_t0_t1 ON event(topic0, topic1);
 CREATE INDEX idx_event_t0_t2 ON event(topic0, topic2);
 CREATE INDEX idx_event_t0_t3 ON event(topic0, topic3);
-CREATE INDEX idx_event_addr_t0_t1_block_log ON event(address, topic0, topic1, block_number DESC, log_index DESC);
-CREATE INDEX idx_event_addr_t0_t2_block_log ON event(address, topic0, topic2, block_number DESC, log_index DESC);
+CREATE INDEX idx_event_addr_t0_t1_block_log ON event(address, topic0, topic1, block_number DESC, transaction_index DESC, log_index DESC);
+CREATE INDEX idx_event_addr_t0_t2_block_log ON event(address, topic0, topic2, block_number DESC, transaction_index DESC, log_index DESC);
 
 CREATE TABLE address_in_event (
 event_id VARCHAR,

--- a/prisma/rsk-explorer-database.sql
+++ b/prisma/rsk-explorer-database.sql
@@ -487,8 +487,12 @@ CREATE INDEX idx_event_address_event_event_id ON event(address, event, event_id 
 CREATE INDEX idx_event_event ON event(event);
 CREATE INDEX idx_event_lowercase_event ON event(lower((event)::text));
 CREATE INDEX idx_event_addr_t0_t3 ON event(address, topic0, topic3, block_number DESC, log_index DESC);
+CREATE INDEX idx_event_addr_t0_block_log_desc ON event(address, topic0, block_number DESC, log_index DESC);
 CREATE INDEX idx_event_t0_t1 ON event(topic0, topic1);
 CREATE INDEX idx_event_t0_t2 ON event(topic0, topic2);
+CREATE INDEX idx_event_t0_t3 ON event(topic0, topic3);
+CREATE INDEX idx_event_addr_t0_t1_block_log ON event(address, topic0, topic1, block_number DESC, log_index DESC);
+CREATE INDEX idx_event_addr_t0_t2_block_log ON event(address, topic0, topic2, block_number DESC, log_index DESC);
 
 CREATE TABLE address_in_event (
 event_id VARCHAR,

--- a/prisma/rsk-explorer-database.sql
+++ b/prisma/rsk-explorer-database.sql
@@ -1,5 +1,8 @@
--- RSK Explorer Database Schema V1.2.3
+-- RSK Explorer Database Schema V1.2.4
 /*
+
+V1.2.4 Notes:
+- Added indexes for NFT support in event table
 
 V1.2.3 Notes:
 - Normalized SQL schema across environments
@@ -483,6 +486,9 @@ CREATE INDEX idx_event_transaction_hash_log_index ON event(transaction_hash, log
 CREATE INDEX idx_event_address_event_event_id ON event(address, event, event_id DESC);
 CREATE INDEX idx_event_event ON event(event);
 CREATE INDEX idx_event_lowercase_event ON event(lower((event)::text));
+CREATE INDEX idx_event_addr_t0_t3 ON event(address, topic0, topic3, block_number DESC, log_index DESC);
+CREATE INDEX idx_event_t0_t1 ON event(topic0, topic1);
+CREATE INDEX idx_event_t0_t2 ON event(topic0, topic2);
 
 CREATE TABLE address_in_event (
 event_id VARCHAR,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -191,6 +191,9 @@ model event {
   @@index([transactionHash, logIndex], map: "idx_event_transaction_hash_log_index")
   @@index([address, event, eventId(sort: Desc)], map: "idx_event_address_event_event_id")
   @@index([event], map: "idx_event_event")
+  @@index([address, topic0, topic3, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t3")
+  @@index([topic0, topic1], map: "idx_event_t0_t1")
+  @@index([topic0, topic2], map: "idx_event_t0_t2")
 }
 
 model internal_transaction {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -191,12 +191,12 @@ model event {
   @@index([transactionHash, logIndex], map: "idx_event_transaction_hash_log_index")
   @@index([address, event, eventId(sort: Desc)], map: "idx_event_address_event_event_id")
   @@index([event], map: "idx_event_event")
-  @@index([address, topic0, topic3, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t3")
+  @@index([address, topic0, topic3, blockNumber(sort: Desc), transactionIndex(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t3")
   @@index([topic0, topic1], map: "idx_event_t0_t1")
   @@index([topic0, topic2], map: "idx_event_t0_t2")
-  @@index([address, topic0, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_block_log_desc")
-  @@index([address, topic0, topic1, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t1_block_log")
-  @@index([address, topic0, topic2, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t2_block_log")
+  @@index([address, topic0, blockNumber(sort: Desc), transactionIndex(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_block_log_desc")
+  @@index([address, topic0, topic1, blockNumber(sort: Desc), transactionIndex(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t1_block_log")
+  @@index([address, topic0, topic2, blockNumber(sort: Desc), transactionIndex(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t2_block_log")
   @@index([topic0, topic3], map: "idx_event_t0_t3")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,6 +194,10 @@ model event {
   @@index([address, topic0, topic3, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t3")
   @@index([topic0, topic1], map: "idx_event_t0_t1")
   @@index([topic0, topic2], map: "idx_event_t0_t2")
+  @@index([address, topic0, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_block_log_desc")
+  @@index([address, topic0, topic1, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t1_block_log")
+  @@index([address, topic0, topic2, blockNumber(sort: Desc), logIndex(sort: Desc)], map: "idx_event_addr_t0_t2_block_log")
+  @@index([topic0, topic3], map: "idx_event_t0_t3")
 }
 
 model internal_transaction {


### PR DESCRIPTION
This pull request updates the database schema to improve support for NFTs by adding new indexes to the `event` table. These changes are reflected in both the raw SQL schema and the Prisma schema definition, which will help optimize queries related to NFT events.

**NFT support and indexing improvements:**

* Added three new indexes to the `event` table in both `prisma/rsk-explorer-database.sql` and `prisma/schema.prisma` to optimize queries for NFT-related data:
  - Index on `(address, topic0, topic3, block_number DESC, log_index DESC)` to speed up lookups involving NFT transfer events. [[1]](diffhunk://#diff-da2ccd6c1bbbf0cb650ddec5da01f8890eace8350a71d3a77c380eed6f5344f2R489-R491) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR194-R196)
  - Index on `(topic0, topic1)` to optimize event queries by topic. [[1]](diffhunk://#diff-da2ccd6c1bbbf0cb650ddec5da01f8890eace8350a71d3a77c380eed6f5344f2R489-R491) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR194-R196)
  - Index on `(topic0, topic2)` for further event filtering efficiency. [[1]](diffhunk://#diff-da2ccd6c1bbbf0cb650ddec5da01f8890eace8350a71d3a77c380eed6f5344f2R489-R491) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR194-R196)

**Documentation:**

* Updated database schema version and notes to reflect the addition of NFT-related indexes.