### PR TITLE
adding a new index on the address_in_event table

### DIFF
--- a/prisma/rsk-explorer-database.sql
+++ b/prisma/rsk-explorer-database.sql
@@ -1,5 +1,8 @@
--- RSK Explorer Database Schema V1.2.4
+-- RSK Explorer Database Schema V1.2.5
 /*
+
+V1.2.5 Notes:
+- Added new index in address_in_event table
 
 V1.2.4 Notes:
 - Added new columns and indexes to verification_result table
@@ -498,6 +501,7 @@ FOREIGN KEY (address) REFERENCES address(address) ON DELETE CASCADE
 );
 CREATE INDEX idx_address_in_event_event_id ON address_in_event(event_id);
 CREATE INDEX ON address_in_event(event_signature);
+CREATE INDEX idx_address_in_event_address_sig_event_id_desc ON address_in_event(address, event_signature, event_id DESC);
 
 CREATE TABLE block_trace (
 block_hash VARCHAR(66),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -548,6 +548,7 @@ model address_in_event {
   @@id([eventId, address, isEventEmitterAddress])
   @@index([eventId], map: "idx_address_in_event_event_id")
   @@index([eventSignature])
+  @@index([address, eventSignature, eventId(sort: Desc)], map: "idx_address_in_event_address_sig_event_id_desc")
 }
 
 model address_latest_balance {


### PR DESCRIPTION
This pull request updates the database schema and Prisma model to add a new composite index to the `address_in_event` table. This change is aimed at improving query performance for operations involving `address`, `eventSignature`, and `eventId` in descending order.

**Database Schema and Model Improvements:**

* Added a new composite index `idx_address_in_event_address_sig_event_id_desc` on the `address_in_event` table for the columns `address`, `event_signature`, and `event_id` in descending order to optimize relevant queries. [[1]](diffhunk://#diff-da2ccd6c1bbbf0cb650ddec5da01f8890eace8350a71d3a77c380eed6f5344f2R504) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR551)
* Updated the schema version and documentation notes to reflect the addition of the new index.