### PR TITLE
DX-1965: upgrade prisma to 6.19.3 and node runtime to 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22 as node
+FROM node:24@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989 as node
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install -y build-essential apt-utils git curl software-properties-common && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e as node
+FROM node:22 as node
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install -y build-essential apt-utils git curl software-properties-common && \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Requisites
 - postgres
-- node: v22+
+- node: v24+
 - access to JSON/RPC interface of a rskj node >= 2.0.1 with this modules enabled: eth, net, web3, txpool, debug and trace.
 
 # Configuration steps

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Requisites
 - postgres
-- node: v16+
+- node: v22+
 - access to JSON/RPC interface of a rskj node >= 2.0.1 with this modules enabled: eth, net, web3, txpool, debug and trace.
 
 # Configuration steps

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.0",
   "description": "RSK Explorer API",
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=24.0.0"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "rsk-explorer-api",
   "version": "2.5.0",
   "description": "RSK Explorer API",
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "main": "index.js",
   "scripts": {
     "dev": "npx nodemon src/api | ./node_modules/.bin/bunyan -o short",
@@ -37,7 +40,7 @@
   "license": "MIT",
   "homepage": "https://github.com/rsksmart/rsk-explorer-api",
   "dependencies": {
-    "@prisma/client": "^5.11.0",
+    "@prisma/client": "6.19.3",
     "@rsksmart/nod3": "^0.5.0",
     "@rsksmart/rsk-contract-parser": "^2.2.0",
     "@rsksmart/rsk-js-cli": "^1.0.0",
@@ -72,7 +75,7 @@
     "eslint-plugin-standard": "^3.1.0",
     "mocha": "^7.2.0",
     "nodemon": "^2.0.4",
-    "prisma": "^5.11.0",
+    "prisma": "6.19.3",
     "sinon": "^20.0.0",
     "swagger-jsdoc": "^3.2.9",
     "swagger-markdown": "^1.4.2"


### PR DESCRIPTION
## DX-1965 — upgrade Prisma to 6.19.3 and Node runtime to 24

Normalizes rsk-explorer-api (the indexer) onto the shared, exact Prisma version (**6.19.3**). This is a **v5.11 → v6.19 major** bump that forces a Node runtime upgrade.

### Changes
- `@prisma/client` & `prisma`: `^5.11.0` → `6.19.3` (exact pin)
- `engines.node`: added `>=24.0.0` (matches Dockerfile + README)
- `Dockerfile`: `node:12` → `node:24` (digest-pinned)
- `README.md`: `node: v16+` → `node: v24+`

### Why the Node bump
Prisma 6.19 requires Node ≥18.18 and the image was on 12, so the jump is unavoidable. Node **24** (current LTS "Krypton") chosen for the longest support horizon; it also clears the future Prisma v7 floor (≥20.19), so no second runtime migration later. The real runtime risk is the OpenSSL 1.1 → 3.0 crossing, not Prisma.

### 📌 Note for NRE team
This bumps the repo Dockerfile base image `node:12 → node:24`. The **production Dockerfile / deploy image** maintained by NRE needs the same Node 12 → 24 bump so prod matches this runtime (mind the OpenSSL 1.1 → 3.0 change and any native-dep rebuilds).

### Why low-risk (Prisma side)
No `Bytes` fields, no preview features. `$queryRaw`/`$executeRaw` behavior is unchanged v5 → v6 (the raw type-mapping break was v4 → v5). Schema validates under 6.19.3.

### Testing (Node 24, local testnet stack)
- Clean install + native rebuild + build on Node 24 (zero gyp errors).
- Continuous block/tx/event indexing; chain **reorgs handled cleanly** (delete-old + insert-new path).
- All 4 `bo_*` aggregation cron jobs (`$executeRaw`) run, finish, and **populate their tables** with zero errors.
- Metrics endpoint live. Zero Prisma-related errors in logs.

Note: lockfile intentionally not committed (repo gitignores it; exact pin makes the version deterministic).

See `prisma-v6-migration.md` for the full write-up. Full logs are also attached to the ticket.
