### PR TITLE
Fix/update submodule commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsk-explorer-api",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "RSK Explorer API",
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
This pull request contains a version bump for the `rsk-explorer-api` package and updates the `prisma` submodule to a new commit. These are routine maintenance changes.

- Versioning:
  * Updated the `version` field in `package.json` from `2.6.0` to `2.6.1` to reflect a new release.

- Dependencies:
  * Updated the `prisma` submodule to point to a newer commit, bringing in the latest changes from that dependency.