### PR TITLE
hotfix: release v2.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "rsk-explorer-api",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rsk-explorer-api",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "6.19.3",
         "@rsksmart/nod3": "^0.5.0",
-        "@rsksmart/rsk-contract-parser": "^2.2.0",
+        "@rsksmart/rsk-contract-parser": "2.2.5",
         "@rsksmart/rsk-js-cli": "^1.0.0",
         "@rsksmart/rsk-utils": "^1.1.0",
         "bignumber.js": "^7.2.1",
@@ -2187,14 +2187,14 @@
       }
     },
     "node_modules/@rsksmart/rsk-contract-parser": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-contract-parser/-/rsk-contract-parser-2.2.4.tgz",
-      "integrity": "sha512-wuxa9p6c9xYgYP0rFgdWuGx1v8g9AmcUupcs1/wNokDFQSBn164m9F4gnfibmhamSYZDChnv71N8szeZZAJxGw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-contract-parser/-/rsk-contract-parser-2.2.5.tgz",
+      "integrity": "sha512-JxuQgLipFuJH38LuygQ7K46H2aPOXfHtEMW23GXaEa7cz1iDqCfEr3CAPPy6jagAutR9UifNZqeJV2mFFAExyg==",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@rsksmart/nod3": "^0.5.0",
-        "@rsksmart/rsk-precompiled-abis": "^8.0.0-REED",
+        "@rsksmart/rsk-precompiled-abis": "^9.0.0-VETIVER",
         "@rsksmart/rsk-utils": "^1.1.0",
         "bs58": "^4.0.1",
         "secp256k1": "^3.7.1"
@@ -2209,9 +2209,9 @@
       "integrity": "sha512-4ysFOd535QjP3/1bSunk9XSndZ7d3Ug+2759C0XSByBZGDn4mNg0uyr7MenX+xjEK44d9L0EjpSgVStGw43eow=="
     },
     "node_modules/@rsksmart/rsk-precompiled-abis": {
-      "version": "8.0.0-REED",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-precompiled-abis/-/rsk-precompiled-abis-8.0.0-REED.tgz",
-      "integrity": "sha512-wKgqrD/8fJOPNRGWY4Gf1N43+W4KSaFhZTool3ZmOkSogfQLl+imnk5wQC8YOIxQy0QJcrvoKtiJBoSQQx4o1g==",
+      "version": "9.0.0-VETIVER",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-precompiled-abis/-/rsk-precompiled-abis-9.0.0-VETIVER.tgz",
+      "integrity": "sha512-PVncMHvqn0tYv60Hhc2xGhbwZHjW5mdKK5NLIZW71uJJlL4EFWANaCHHC/DxHyisRf7Q29d9dH1Aw6nP192bAw==",
       "license": "ISC"
     },
     "node_modules/@rsksmart/rsk-utils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsk-explorer-api",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "RSK Explorer API",
   "engines": {
     "node": ">=24.0.0"
@@ -42,7 +42,7 @@
   "dependencies": {
     "@prisma/client": "6.19.3",
     "@rsksmart/nod3": "^0.5.0",
-    "@rsksmart/rsk-contract-parser": "^2.2.0",
+    "@rsksmart/rsk-contract-parser": "2.2.5",
     "@rsksmart/rsk-js-cli": "^1.0.0",
     "@rsksmart/rsk-utils": "^1.1.0",
     "bignumber.js": "^7.2.1",


### PR DESCRIPTION
Updated the `@rsksmart/rsk-contract-parser` dependency to `2.2.5` in `package.json` to fix an issue that causes some blocks to not being stored due to ERC-1155 parsing.
